### PR TITLE
use rapidfuzz instead of fuzzywuzzy

### DIFF
--- a/htools/core.py
+++ b/htools/core.py
@@ -1,7 +1,7 @@
 from bz2 import BZ2File
 from collections import namedtuple, UserDict, Sequence, Mapping
 from email.mime.text import MIMEText
-from fuzzywuzzy import fuzz, process
+from rapidfuzz import fuzz, process
 import inspect
 from itertools import chain
 import json

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-fuzzywuzzy[speedup]
+rapidfuzz
 ipython


### PR DESCRIPTION
FuzzyWuzzy is GPLv2 licensed which would force you to licence the whole project under GPLv2.
For this reason this Pullrequest replaces FuzzyWuzzy with  [rapidfuzz](https://github.com/rhasspy/rapidfuzz) which is implementing the same algorithm but is based on a version of fuzzywuzzy that was MIT Licensed.
Rapidfuzz is:
- Mit licensed so it can be used with the license used by this project
- Is faster than FuzzyWuzzy